### PR TITLE
fix an issue that the audio would not continue to play when the user …

### DIFF
--- a/library/src/main/java/com/devbrackets/android/playlistcore/service/PlaylistServiceCore.java
+++ b/library/src/main/java/com/devbrackets/android/playlistcore/service/PlaylistServiceCore.java
@@ -585,9 +585,13 @@ public abstract class PlaylistServiceCore<I extends IPlaylistItem, M extends Bas
      * media item.  This is called through an intent
      * with the {@link RemoteActions#ACTION_SEEK_ENDED}, through
      * {@link BasePlaylistManager#invokeSeekEnded(int)}
+     *
+     * resume the playback for ExoPlayer as it won't have the callback of
+     * {@link OnMediaSeekCompletionListener#onSeekComplete(MediaPlayerApi))}
      */
     protected void performSeekEnded(int newPosition) {
         performSeek(newPosition);
+        resumePlaybackIfNecessary();
     }
 
     /**
@@ -1150,12 +1154,7 @@ public abstract class PlaylistServiceCore<I extends IPlaylistItem, M extends Bas
 
         @Override
         public void onSeekComplete(@NonNull MediaPlayerApi mediaPlayerApi) {
-            if (pausedForSeek) {
-                performPlay();
-                pausedForSeek = false;
-            } else {
-                performPause();
-            }
+            resumePlaybackIfNecessary();
         }
 
         @Override
@@ -1185,6 +1184,13 @@ public abstract class PlaylistServiceCore<I extends IPlaylistItem, M extends Bas
             }
 
             return false;
+        }
+    }
+
+    private void resumePlaybackIfNecessary() {
+        if (pausedForSeek) {
+            performPlay();
+            pausedForSeek = false;
         }
     }
 }


### PR DESCRIPTION
###### Fixes issue #4 .
- [ ] This pull request follows the coding standards
###### This PR changes:
-  

fix an issue that the audio would not continue to play when the user completes dragging the seek bar,  which could only be reproduced using ExoPlayer rather MediaPlayer. You could reproduce this issue using the demo from ExoMedia 3.0 Branch which actually use ExoPlayer on Android API above or equal 16. The root cause of this problem is that ExoPlayer does not have onSeekCompletion callback.
