### PR TITLE
[Fixes #67] Fixed the DefaultPlaylistHandler entering a bad state after disconnecting from remote media players

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     //...
-    compile 'com.devbrackets.android:playlistcore:2.0.0'
+    compile 'com.devbrackets.android:playlistcore:2.0.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.2.31'
+    ext.kotlinVersion = '1.2.40'
 
     repositories {
         jcenter()
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.1.1'
         classpath 'com.novoda:bintray-release:0.8.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     implementation "com.android.support:support-v4:$rootProject.ext.supportLibVersion"
     implementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibVersion"
     implementation "com.android.support:support-annotations:$rootProject.ext.supportLibVersion"
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
 
     // Chromecast support
     implementation "com.android.support:mediarouter-v7:$rootProject.ext.supportLibVersion"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.novoda.bintray-release'
 
 def versionMajor = 2
 def versionMinor = 0
-def versionPatch = 0
+def versionPatch = 1
 
 def libraryGroupId = 'com.devbrackets.android'
 def libraryBaseName = 'playlistcore'

--- a/library/src/main/kotlin/com/devbrackets/android/playlistcore/components/playlisthandler/DefaultPlaylistHandler.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/playlistcore/components/playlisthandler/DefaultPlaylistHandler.kt
@@ -323,7 +323,9 @@ open class DefaultPlaylistHandler<I : PlaylistItem, out M : BasePlaylistManager<
             this.startPaused = startPaused
 
             updateCurrentMediaPlayer(it)
-            play(currentMediaPlayer, it)
+            if (!play(currentMediaPlayer, it)) {
+                next()
+            }
         }
     }
 
@@ -400,6 +402,11 @@ open class DefaultPlaylistHandler<I : PlaylistItem, out M : BasePlaylistManager<
     }
 
     protected open fun updateCurrentMediaPlayer(item: I?) {
+        if (mediaPlayers.isEmpty()) {
+            Log.d(TAG, "No media players available, stopping service")
+            stop()
+        }
+
         val newMediaPlayer = item?.let { getMediaPlayerForItem(it) }
         if (newMediaPlayer != currentMediaPlayer) {
             listener?.onMediaPlayerChanged(currentMediaPlayer, newMediaPlayer)


### PR DESCRIPTION
###### Fixes issue #67
- [x] This pull request follows the coding standards

###### This PR changes:
 -  Fixed an issue where the playlist would be stuck in a bad state after disconnecting from a remote media player without any available mediaPlayers

